### PR TITLE
chore: bump deprecated node20 GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,12 +21,12 @@ jobs:
         uses: actions/checkout@main
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
         with:
           platforms: linux/arm64
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: set build outputs
         run: |
@@ -36,7 +36,7 @@ jobs:
           echo "BASE_TAG=$tag" >> $GITHUB_ENV
 
       - name: Bake the ${{ matrix.target }} image
-        uses: docker/bake-action@v6
+        uses: docker/bake-action@v7
         with:
           targets: ${{ matrix.target }}
           push: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,19 +24,19 @@ jobs:
           fetch-depth: 0
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
         with:
           platforms: linux/arm64
 
       - name: Log in to GitHub registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: set build outputs
         run: |
@@ -46,7 +46,7 @@ jobs:
           echo "BASE_TAG=$tag" >> $GITHUB_ENV
 
       - name: Bake the ${{ matrix.target }} image
-        uses: docker/bake-action@v6
+        uses: docker/bake-action@v7
         with:
           targets: ${{ matrix.target }}
           push: true


### PR DESCRIPTION
Bumps GitHub Actions that were using the deprecated Node.js 20 runtime.

## Changes
- `docker/bake-action@v6 → docker/bake-action@v7`
- `docker/login-action@v3 → docker/login-action@v4`
- `docker/setup-buildx-action@v3 → docker/setup-buildx-action@v4`
- `docker/setup-qemu-action@v3 → docker/setup-qemu-action@v4`

## Why
Node.js 20 reached EOL in April 2026 and GitHub is deprecating it on Actions runners.
See: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

> ⚠️ Actions with potentially breaking changes (custom configs, major API changes) are excluded and need manual review.

🤖 Generated with Claude Code
👦🏻 Reviewed by human